### PR TITLE
Update LICENSE_HEADER.md 

### DIFF
--- a/LICENSE_HEADER.md
+++ b/LICENSE_HEADER.md
@@ -71,7 +71,7 @@ See COPYING.txt for license details.
 
 We will continue to add examples of headers for other licenses as they come up. For now, if you are not using Apache V2, make sure to add a copyright header to all source files where it makes sense (do not add them to `.json` or machine-generated files).
 
-To learn more about Adobe copyright, checkout our [Copyrights documentation](https://inside.corp.adobe.com/intellectual-property/copyrights.html#jcr-content_par_tab_Adobe-Copyright-Notices).
+To learn more about Adobe copyright, checkout our [Copyrights documentation](https://www.adobe.com/legal/permissions.html).
 
 ### Text
 


### PR DESCRIPTION
Link updated.

Just changed de Adobe copyright url.

## Description

Replaced deprecated url with the right Adobe copyright link.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #10

## Motivation and Context

If the user wants to go deeper into Adobe copyright then the link should point to the right page.

## How Has This Been Tested?

Replaced the link and tested it.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
