### PR TITLE
Update LICENSE_HEADER.md

### DIFF
--- a/LICENSE_HEADER.md
+++ b/LICENSE_HEADER.md
@@ -71,8 +71,6 @@ See COPYING.txt for license details.
 
 We will continue to add examples of headers for other licenses as they come up. For now, if you are not using Apache V2, make sure to add a copyright header to all source files where it makes sense (do not add them to `.json` or machine-generated files).
 
-To learn more about Adobe copyright, checkout our [Copyrights documentation](https://inside.corp.adobe.com/intellectual-property/copyrights.html#jcr-content_par_tab_Adobe-Copyright-Notices).
-
 ### Text
 
 ```


### PR DESCRIPTION
Removed Learn more about Adobe Copyright Part

## Description

Changed License Header file by removing the line 74 

## Related Issue

https://github.com/adobe/starter-repo/issues/10

## Motivation and Context

The Copyright URL was of the Adobe Corporate instead of Apache Copyright URL

## How Has This Been Tested?

Markdown edit, doesn't require explicit testing.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

