### PR TITLE
Update LICENSE_HEADER.md

### DIFF
--- a/LICENSE_HEADER.md
+++ b/LICENSE_HEADER.md
@@ -16,7 +16,7 @@ governing permissions and limitations under the License.
 
 ### Javascript, Java, C, C++, Swift, Go, Objective C
 
-```
+```js
 /*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -32,16 +32,16 @@ governing permissions and limitations under the License.
 
 ### Bash, Ruby, Python 
 
-```
-#Copyright 2020 Adobe. All rights reserved.
-#This file is licensed to you under the Apache License, Version 2.0 (the "License");
-#you may not use this file except in compliance with the License. You may obtain a copy
-#of the License at http://www.apache.org/licenses/LICENSE-2.0
+```bash
+# Copyright 2020 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
 
-#Unless required by applicable law or agreed to in writing, software distributed under
-#the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
-#OF ANY KIND, either express or implied. See the License for the specific language
-#governing permissions and limitations under the License.
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
 ```
 
 ### Windows Batch File
@@ -84,7 +84,7 @@ it.
 
 ### Javascript, Java, C, C++, Swift, Go, Objective C
 
-```
+```js
 /*
 Copyright 2020 Adobe
 All Rights Reserved.
@@ -97,7 +97,7 @@ it.
 
 ### Bash, Ruby, Python 
 
-```
+```bash
 # Copyright 2020 Adobe
 # All Rights Reserved.
 


### PR DESCRIPTION
Added missing spaces after `#` in Bash, Ruby, Python snippet.

I also added formatting types for the code blocks
